### PR TITLE
refactor: remove frr exporter and add build packaging scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 /sonic-exporter
+/build/
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ $ docker-compose down
 $ docker-compose up --build -d
 ```
 
+4. To build a local binary:
+```bash
+$ ./scripts/build.sh
+```
+
+This script builds a static Linux binary (`CGO_ENABLED=0`), which is safer for older SONiC images.
+
+Optional cross-build example:
+```bash
+$ TARGET_OS=linux TARGET_ARCH=amd64 ./scripts/build.sh
+```
+
+5. To build a release tarball (binary + sha256):
+```bash
+$ ./scripts/package.sh
+```
+
+Optional package version override:
+```bash
+$ VERSION=v0.1.0 ./scripts/package.sh
+```
+
 In case you need to add additional keys to redis database don't forget to run `SAVE` in redis after doing so:
 ```bash
 $ redis-cli

--- a/cmd/sonic-exporter/main.go
+++ b/cmd/sonic-exporter/main.go
@@ -12,22 +12,23 @@ import (
 	"github.com/prometheus/exporter-toolkit/web"
 	webflag "github.com/prometheus/exporter-toolkit/web/kingpinflag"
 	nodecollector "github.com/prometheus/node_exporter/collector"
-	frrcollector "github.com/tynany/frr_exporter/collector"
 	"github.com/vinted/sonic-exporter/internal/collector"
 )
 
 func main() {
-	// setup frr and node exporters (default flag values + hardcoded flags)
+	// setup node exporter collectors through global kingpin flags
 	kingpin.CommandLine.Parse([]string{
-		"--frr.vtysh",
-		"--collector.bgp6",
-		"--collector.bgpl2vpn",
-		"--no-collector.route",
-		"--no-collector.bfd",
-		"--no-collector.ospf",
+		"--collector.disable-defaults",
+		"--collector.loadavg",
+		"--collector.cpu",
+		"--collector.diskstats",
+		"--collector.filesystem",
+		"--collector.meminfo",
+		"--collector.time",
+		"--collector.stat",
 	})
 
-	// New kingpin instance to prevent imported code from adding flags (frr and node exporters)
+	// New kingpin instance to prevent imported code from adding flags (node exporter)
 	kp := kingpin.New("sonic-exporter", "Prometheus exporter for SONiC network switches")
 
 	var (
@@ -68,14 +69,6 @@ func main() {
 		os.Exit(1)
 	}
 	prometheus.MustRegister(nodeCollector)
-
-	// FRR exporter
-	frrExporter, err := frrcollector.NewExporter(logger)
-	if err != nil {
-		logger.Error("Failed to create FRR exporter", "error", err)
-		os.Exit(1)
-	}
-	prometheus.MustRegister(frrExporter)
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/prometheus/exporter-toolkit v0.14.1
 	github.com/prometheus/node_exporter v1.10.2
 	github.com/redis/go-redis/v9 v9.6.1
-	github.com/tynany/frr_exporter v1.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,6 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tynany/frr_exporter v1.9.0 h1:f3QgDLAdLr/KMzHUOideExgCsekWAXI7lpdLwPEno7s=
-github.com/tynany/frr_exporter v1.9.0/go.mod h1:zEhDjSwYtOkHmWF3j6oDy7WtgXF15TutSSpe7fyKxUs=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${REPO_ROOT}/build"
+OUTPUT_BIN="${OUTPUT_DIR}/sonic-exporter"
+TARGET_OS="${TARGET_OS:-linux}"
+TARGET_ARCH="${TARGET_ARCH:-amd64}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "Building sonic-exporter for ${TARGET_OS}/${TARGET_ARCH} (static)..."
+CGO_ENABLED=0 GOOS="${TARGET_OS}" GOARCH="${TARGET_ARCH}" go build -trimpath -ldflags "-s -w" -o "${OUTPUT_BIN}" "${REPO_ROOT}/cmd/sonic-exporter"
+
+echo "Done: ${OUTPUT_BIN}"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_SCRIPT="${REPO_ROOT}/scripts/build.sh"
+OUTPUT_DIR="${REPO_ROOT}/build"
+
+VERSION="${VERSION:-$(git -C "${REPO_ROOT}" rev-parse --short HEAD)}"
+TARGET_OS="${TARGET_OS:-linux}"
+TARGET_ARCH="${TARGET_ARCH:-amd64}"
+
+BIN_NAME="sonic-exporter"
+PKG_BASE="${BIN_NAME}-${VERSION}-${TARGET_OS}-${TARGET_ARCH}"
+STAGE_DIR="${OUTPUT_DIR}/${PKG_BASE}"
+ARCHIVE_PATH="${OUTPUT_DIR}/${PKG_BASE}.tar.gz"
+CHECKSUM_PATH="${ARCHIVE_PATH}.sha256"
+
+"${BUILD_SCRIPT}"
+
+rm -rf "${STAGE_DIR}"
+mkdir -p "${STAGE_DIR}"
+
+cp "${OUTPUT_DIR}/${BIN_NAME}" "${STAGE_DIR}/${BIN_NAME}"
+
+tar -C "${OUTPUT_DIR}" -czf "${ARCHIVE_PATH}" "${PKG_BASE}"
+sha256sum "${ARCHIVE_PATH}" > "${CHECKSUM_PATH}"
+
+rm -rf "${STAGE_DIR}"
+
+printf "Package: %s\nChecksum: %s\n" "${ARCHIVE_PATH}" "${CHECKSUM_PATH}"


### PR DESCRIPTION
**Summary**
This PR removes the FRR exporter from sonic-exporter and keeps only SONiC + node exporter metrics.  
It also adds a simple build/package workflow so we can generate a static binary and a release tarball for older SONiC images (Debian 10 / older glibc).
**Changes**
- Removed FRR exporter integration from cmd/sonic-exporter/main.go
  - dropped FRR import
  - removed FRR initialization and registration
- Removed github.com/tynany/frr_exporter from dependencies (go.mod, go.sum)
- Fixed node exporter startup after FRR removal by explicitly enabling required collectors through global kingpin flags:
  - loadavg, cpu, diskstats, filesystem, meminfo, time, stat
- Added scripts/build.sh
  - builds static Linux binary (CGO_ENABLED=0) to avoid glibc runtime mismatch on SONiC
- Added scripts/package.sh
  - builds tarball + sha256 checksum for easy transfer/deploy
- Updated README.md with build and package instructions
- Added /build/ to .gitignore
**Why**
- FRR metrics are not needed right now.
- Previous binary failed on target SONiC with:
  - GLIBC_2.34 not found
  - GLIBC_2.32 not found
- Static build removes dependency on target glibc version and is safer for mixed/older SONiC environments.
**Verification**
- go test ./...
- ./scripts/build.sh
- ./scripts/package.sh
- ./build/sonic-exporter --help
- Runtime smoke test confirms exporter starts without the previous node collector error.
Operator impact
- FRR metrics are no longer exposed.
- Build/release flow is now:
  1. ./scripts/build.sh
  2. ./scripts/package.sh
- Deploy using generated build/*.tar.gz and verify with *.sha256.